### PR TITLE
Fixed installation for 2024+, related to hass.helpers

### DIFF
--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -1,0 +1,18 @@
+name: Validate
+
+on:
+  push:
+  pull_request:
+  schedule:
+    - cron: "0 0 * * *"
+  workflow_dispatch:
+
+jobs:
+  validate-hacs:
+    runs-on: "ubuntu-latest"
+    steps:
+      - uses: "actions/checkout@v3"
+      - name: HACS validation
+        uses: "hacs/action@main"
+        with:
+          category: "integration"

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -11,7 +11,6 @@ jobs:
   validate-hacs:
     runs-on: "ubuntu-latest"
     steps:
-      - uses: "actions/checkout@v3"
       - name: HACS validation
         uses: "hacs/action@main"
         with:

--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ HeaterMeter smoker controller integration for HA.
 
 ## Getting started
 * Copy the 'heatermeter' folder to the Home Assistant config/custom_components/ directory.  
+  or add and download the repository:
+https://my.home-assistant.io/redirect/supervisor_add_addon_repository/?repository_url=https%3A%2F%2Fgithub.com%2Fdrewkeller%2FHAHeaterMeter (temporarily using this repo to see if HACS will show it)
 
 [:top:](#bookmark_tabs-table-of-contents)
 <br/>

--- a/README.md
+++ b/README.md
@@ -77,9 +77,23 @@ HeaterMeter smoker controller integration for HA.
 <br/>
 
 ## Getting started
+
+### Manually copy
 * Copy the 'heatermeter' folder to the Home Assistant config/custom_components/ directory.  
-  or add and download the repository:
-https://my.home-assistant.io/redirect/supervisor_add_addon_repository/?repository_url=https%3A%2F%2Fgithub.com%2Fdrewkeller%2FHAHeaterMeter (temporarily using this repo to see if HACS will show it)
+
+### Add the repository to HACs
+  * Add the repository to HACs (this has not been assigned a brand, so it is not a "valid" HACs repository, so this button does not currently work correctly)
+  [![Open your Home Assistant instance and show the add add-on repository dialog with a specific repository URL pre-filled.](https://my.home-assistant.io/badges/supervisor_add_addon_repository.svg)](https://my.home-assistant.io/redirect/supervisor_add_addon_repository/?repository_url=https%3A%2F%2Fgithub.com%2Fdrewkeller%2FHAHeaterMeter)
+  1. (since above button doesn't successfully add the repo...) Open HACs n Home Assistant
+  2. Click the three dots at the top right of the page, to the far right of the title on "Home Assistant Community Store"
+  3. Select "Custom repositories"
+  4. In the popup...
+    Enter the URL for this repository
+    Select "Integration" for the type
+    Click the "Add" button
+  5. Find the repository in the HACS list
+  6. Select the three dots to the right of the repository and select "Download"
+
 
 [:top:](#bookmark_tabs-table-of-contents)
 <br/>

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ HeaterMeter smoker controller integration for HA.
   If you prefer the legacy -1 values to represent a disabled alarm, you can find an updated script in: "legacy_update_heatermeter_input_numbers.yaml"
 
 ## Changes:
-- Fixed depreciated constants (TEMP_CELSIUS/TEMP_FAHRENHEIT) to UnitOfTemperature
+- Fixed deprecated constants (TEMP_CELSIUS/TEMP_FAHRENHEIT) to UnitOfTemperature
   - (legacy constants to be removed in 2025.1)
 - Negative Alarm values are sync'd (rather than displaying -1).
 - Updated YAML to include default values for INT and FLOAT values in templates.
@@ -36,6 +36,7 @@ HeaterMeter smoker controller integration for HA.
 - Lovelace Card Updates:
   * Now includes a card for setting the Set Point with a slider and 'Set' button.
   * Added history graph for the fan.
+- Fixed installation for 2024+, related to hass.helpers (see https://developers.home-assistant.io/blog/2024/03/30/deprecate-hass-helpers/)
 <br/>
 
 ## :heavy_check_mark: ToDo:

--- a/custom_components/heatermeter/__init__.py
+++ b/custom_components/heatermeter/__init__.py
@@ -16,6 +16,9 @@ import voluptuous as vol
 from homeassistant.const import (
         CONF_HOST, CONF_PORT, CONF_API_KEY, CONF_SCAN_INTERVAL
     )
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.typing import ConfigType
+from homeassistant.helpers.discovery import load_platform
 
 DOMAIN = 'heatermeter'
 
@@ -37,7 +40,7 @@ ALARM_DEFAULT = '-190,-250,-1,-205,-100,-100,-100,-100'
 _LOGGER = logging.getLogger(__name__)
 
 
-def setup(hass, config):
+def setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Set up is called when Home Assistant is loading our component."""
     _LOGGER.debug("HeaterMeter init.py: config = %s", config[DOMAIN])
 
@@ -130,7 +133,7 @@ def setup(hass, config):
     hass.services.register(DOMAIN, 'set_alarms', handle_setalarms_api)
 
 
-    hass.helpers.discovery.load_platform('sensor', DOMAIN, {}, config)
+    load_platform(hass, 'sensor', DOMAIN, {}, config)
 
     # Return boolean to indicate that initialization was successfully.
     return True

--- a/custom_components/heatermeter/manifest.json
+++ b/custom_components/heatermeter/manifest.json
@@ -2,6 +2,7 @@
   "domain": "heatermeter",
   "name": "HeaterMeter BBQ Controller",
   "documentation": "https://github.com/ledhed-jgh/HAHeaterMeter",
+  "issue_tracker": "https://github.com/ledhed-jgh/HAHeaterMeter/issues",
   "dependencies": [],
   "codeowners": [],
   "requirements": [],

--- a/custom_components/heatermeter/manifest.json
+++ b/custom_components/heatermeter/manifest.json
@@ -2,7 +2,6 @@
   "domain": "heatermeter",
   "name": "HeaterMeter BBQ Controller",
   "documentation": "https://github.com/ledhed-jgh/HAHeaterMeter",
-  "issue_tracker": "https://github.com/ledhed-jgh/HAHeaterMeter/issues",
   "dependencies": [],
   "codeowners": [],
   "requirements": [],

--- a/custom_components/heatermeter/manifest.json
+++ b/custom_components/heatermeter/manifest.json
@@ -2,7 +2,6 @@
   "domain": "heatermeter",
   "name": "HeaterMeter BBQ Controller",
   "documentation": "https://github.com/drewkeller/HAHeaterMeter",
-  "issue_tracker": "https://github.com/drewkeller/HAHeaterMeter/issues",
   "dependencies": [],
   "codeowners": [],
   "requirements": [],

--- a/custom_components/heatermeter/manifest.json
+++ b/custom_components/heatermeter/manifest.json
@@ -1,12 +1,15 @@
 {
   "domain": "heatermeter",
   "name": "HeaterMeter BBQ Controller",
-  "documentation": "https://github.com/ledhed-jgh/HAHeaterMeter",
+  "documentation": "https://github.com/drewkeller/HAHeaterMeter",
+  "issue_tracker": "https://github.com/drewkeller/HAHeaterMeter/issues",
   "dependencies": [],
   "codeowners": [],
   "requirements": [],
-  "version": "2021.03.06",
+  "version": "2025.05.01",
   "zeroconf": [
     {"type":"_http._tcp.local.","name":"HeaterMeter BBQ Controller*"}
-   ]
+   ],
+   "integration_type": "device",
+   "iot_class": "local_polling"
 }

--- a/hacs.json
+++ b/hacs.json
@@ -1,3 +1,4 @@
 {
-  "name": "HeaterMeter"
+  "name": "HeaterMeter",
+  "render_readme": true
 }

--- a/hacs.json
+++ b/hacs.json
@@ -1,4 +1,6 @@
 {
   "name": "HeaterMeter",
+  "zip_release": true,
+  "filename": "heatermeter.zip",
   "render_readme": true
 }


### PR DESCRIPTION
see https://developers.home-assistant.io/blog/2024/03/30/deprecate-hass-helpers/

The update fixes the following error at startup after installing HeaterMeter:

```
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/setup.py", line 426, in _async_setup_component
    result = await task
             ^^^^^^^^^^
  File "/usr/local/lib/python3.13/concurrent/futures/thread.py", line 59, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/config/custom_components/heatermeter/__init__.py", line 133, in setup
    hass.helpers.discovery.load_platform('sensor', DOMAIN, {}, config)
    ^^^^^^^^^^^^
AttributeError: 'HomeAssistant' object has no attribute 'helpers'
```
